### PR TITLE
Fix multiple enters

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ We could have pursued this compositional approach to add `elapsed_milliseconds` 
 instead of baking it in [`JsonStorage`] itself.
 
 [`Layer`]: https://docs.rs/tracing-subscriber/0.2.5/tracing_subscriber/layer/trait.Layer.html
-[`JsonStorageLayer`]: https://docs.rs/tracing-bunyan-formatter/0.1.4/tracing_bunyan_formatter/struct.JsonStorageLayer.html
-[`JsonStorage`]: https://docs.rs/tracing-bunyan-formatter/0.1.4/tracing_bunyan_formatter/struct.JsonStorage.html
-[`BunyanFormattingLayer`]: https://docs.rs/tracing-bunyan-formatter/0.1.4/tracing_bunyan_formatter/struct.BunyanFormattingLayer.html
+[`JsonStorageLayer`]: https://docs.rs/tracing-bunyan-formatter/0.1.6/tracing_bunyan_formatter/struct.JsonStorageLayer.html
+[`JsonStorage`]: https://docs.rs/tracing-bunyan-formatter/0.1.6/tracing_bunyan_formatter/struct.JsonStorage.html
+[`BunyanFormattingLayer`]: https://docs.rs/tracing-bunyan-formatter/0.1.6/tracing_bunyan_formatter/struct.BunyanFormattingLayer.html
 [`Span`]: https://docs.rs/tracing/0.1.13/tracing/struct.Span.html
 [`Subscriber`]: https://docs.rs/tracing-core/0.1.10/tracing_core/subscriber/trait.Subscriber.html
 [`tracing`]: https://docs.rs/tracing

--- a/src/formatting_layer.rs
+++ b/src/formatting_layer.rs
@@ -10,6 +10,7 @@ use tracing_subscriber::fmt::MakeWriter;
 use tracing_subscriber::layer::Context;
 use tracing_subscriber::registry::SpanRef;
 use tracing_subscriber::Layer;
+use tracing_core::span::Attributes;
 
 /// Keys for core fields of the Bunyan format (https://github.com/trentm/node-bunyan#core-fields)
 const BUNYAN_VERSION: &str = "v";
@@ -239,14 +240,14 @@ where
         }
     }
 
-    fn on_enter(&self, id: &Id, ctx: Context<'_, S>) {
+    fn new_span(&self, _attrs: &Attributes, id: &Id, ctx: Context<'_, S>) {
         let span = ctx.span(id).expect("Span not found, this is a bug");
         if let Ok(serialized) = self.serialize_span(&span, Type::EnterSpan) {
             let _ = self.emit(serialized);
         }
     }
 
-    fn on_exit(&self, id: &Id, ctx: Context<'_, S>) {
+    fn on_close(&self, id: &Id, ctx: Context<'_, S>) {
         let span = ctx.span(id).expect("Span not found, this is a bug");
         if let Ok(serialized) = self.serialize_span(&span, Type::ExitSpan) {
             let _ = self.emit(serialized);

--- a/src/formatting_layer.rs
+++ b/src/formatting_layer.rs
@@ -5,12 +5,12 @@ use std::fmt;
 use std::io::Write;
 use tracing::{Event, Id, Subscriber};
 use tracing_core::metadata::Level;
+use tracing_core::span::Attributes;
 use tracing_log::AsLog;
 use tracing_subscriber::fmt::MakeWriter;
 use tracing_subscriber::layer::Context;
 use tracing_subscriber::registry::SpanRef;
 use tracing_subscriber::Layer;
-use tracing_core::span::Attributes;
 
 /// Keys for core fields of the Bunyan format (https://github.com/trentm/node-bunyan#core-fields)
 const BUNYAN_VERSION: &str = "v";

--- a/src/formatting_layer.rs
+++ b/src/formatting_layer.rs
@@ -247,8 +247,8 @@ where
         }
     }
 
-    fn on_close(&self, id: &Id, ctx: Context<'_, S>) {
-        let span = ctx.span(id).expect("Span not found, this is a bug");
+    fn on_close(&self, id: Id, ctx: Context<'_, S>) {
+        let span = ctx.span(&id).expect("Span not found, this is a bug");
         if let Ok(serialized) = self.serialize_span(&span, Type::ExitSpan) {
             let _ = self.emit(serialized);
         }

--- a/src/storage_layer.rs
+++ b/src/storage_layer.rs
@@ -145,8 +145,8 @@ impl<S: Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>> Layer
     }
 
     /// When we close a span, register how long it took in milliseconds.
-    fn on_close(&self, span: &Id, ctx: Context<'_, S>) {
-        let span = ctx.span(span).expect("Span not found, this is a bug");
+    fn on_close(&self, span: Id, ctx: Context<'_, S>) {
+        let span = ctx.span(&span).expect("Span not found, this is a bug");
 
         // Using a block to drop the immutable reference to extensions
         // given that we want to borrow it mutably just below

--- a/src/storage_layer.rs
+++ b/src/storage_layer.rs
@@ -145,7 +145,7 @@ impl<S: Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>> Layer
     }
 
     /// When we close a span, register how long it took in milliseconds.
-    fn on_exit(&self, span: &Id, ctx: Context<'_, S>) {
+    fn on_close(&self, span: &Id, ctx: Context<'_, S>) {
         let span = ctx.span(span).expect("Span not found, this is a bug");
 
         // Using a block to drop the immutable reference to extensions


### PR DESCRIPTION
Make sure to only log start and end once, when the span is created and when the span is dropped.