### PR TITLE
Make "elapsed_milliseconds" independent from the "arbitrary-precision" feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ instead of baking it in [`JsonStorage`] itself.
 
 You can enable the `arbitrary_precision` feature to handle numbers of arbitrary size losslessly. Be aware of a [known issue with untagged deserialization](https://github.com/LukeMathWalker/tracing-bunyan-formatter/issues/4).
 
+## Testing
+
+Currently the tests only support being run sequentially, so the number of threads needs to be restricted:
+
+`cargo test -- --test-threads 1`
+
 [`Layer`]: https://docs.rs/tracing-subscriber/0.2.5/tracing_subscriber/layer/trait.Layer.html
 [`JsonStorageLayer`]: https://docs.rs/tracing-bunyan-formatter/0.1.6/tracing_bunyan_formatter/struct.JsonStorageLayer.html
 [`JsonStorage`]: https://docs.rs/tracing-bunyan-formatter/0.1.6/tracing_bunyan_formatter/struct.JsonStorage.html

--- a/src/storage_layer.rs
+++ b/src/storage_layer.rs
@@ -160,6 +160,11 @@ impl<S: Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>> Layer
                 .unwrap_or(0)
         };
 
+        #[cfg(not(feature = "arbitrary_precision"))]
+        // without the arbitrary_precision feature u128 values are not supported,
+        // but u64 is still more than enough for our purposes
+        let elapsed_milliseconds = elapsed_milliseconds as u64;
+
         let mut extensions_mut = span.extensions_mut();
         let visitor = extensions_mut
             .get_mut::<JsonStorage>()

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -112,3 +112,18 @@ fn parent_properties_are_propagated() {
         assert!(record.get("parent_property").is_some());
     }
 }
+
+#[test]
+fn elapsed_milliseconds_are_present_on_exit_span() {
+    let tracing_output = run_and_get_output(test_action);
+
+    for record in tracing_output {
+        if record
+            .get("msg")
+            .and_then(Value::as_str)
+            .map_or(false, |msg| msg.ends_with("END]"))
+        {
+            assert!(record.get("elapsed_milliseconds").is_some());
+        }
+    }
+}


### PR DESCRIPTION
`serde_json` supports `u128` values only when the arbitrary-precision
feature is enabled. Since we're unlikely to hit a duration longer that
about 585 million years, we're fine with truncating that value to a
`u64`, so that we can report the elapsed time even without the
arbitrary-precision feature.

Fixes #6
