### PR TITLE
issue 13: encode f64 as numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,25 @@
 version = 3
 
 [[package]]
+name = "autocfg"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "claim"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81099d6bb72e1df6d50bb2347224b666a670912bb7f06dbe867a4a070ab3ce8"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "gethostname"
@@ -165,6 +180,7 @@ dependencies = [
 name = "tracing-bunyan-formatter"
 version = "0.3.3-alpha.0"
 dependencies = [
+ "claim",
  "gethostname",
  "lazy_static",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ tracing-core = "0.1.10"
 time = { version = "0.3", default-features = false, features = ["formatting"] }
 
 [dev-dependencies]
+claim = "0.5.0"
 lazy_static = "1.4.0"
 tracing = { version = "0.1.13", default-features = false, features = ["log", "std", "attributes"] }
 time = { version = "0.3", default-features = false, features = ["formatting", "parsing", "local-offset"] }

--- a/src/storage_layer.rs
+++ b/src/storage_layer.rs
@@ -60,6 +60,12 @@ impl Visit for JsonStorage<'_> {
             .insert(field.name(), serde_json::Value::from(value));
     }
 
+    /// Visit a 64-bit floating point value.
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.values
+            .insert(field.name(), serde_json::Value::from(value));
+    }
+
     /// Visit a boolean value.
     fn record_bool(&mut self, field: &Field, value: bool) {
         self.values

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -115,19 +115,16 @@ fn encode_f64_as_numbers() {
         info!("testing f64");
     };
     let tracing_output = run_and_get_output(action);
-    let info_entry: Vec<&Value> = tracing_output
-        .iter()
-        .filter(|r| {
-            r.get("msg")
-                .and_then(|m| m.as_str())
-                .filter(|m| m.contains("testing f64"))
-                .is_some()
-        })
-        .collect();
 
-    for record in info_entry {
-        let observed_value = record.get("f64_field").and_then(|v| v.as_f64());
-        assert_some_eq!(observed_value, f64_value);
+    for record in tracing_output {
+        if record
+            .get("msg")
+            .and_then(Value::as_str)
+            .map_or(false, |msg| msg.contains("testing f64"))
+        {
+            let observed_value = record.get("f64_field").and_then(|v| v.as_f64());
+            assert_some_eq!(observed_value, f64_value);
+        }
     }
 }
 


### PR DESCRIPTION
Fix https://github.com/LukeMathWalker/tracing-bunyan-formatter/issues/13

The test "parent_properties_are_propagated" is failing when run along with the new test.
I'd need help here to fix that.