### PR TITLE
Migrate from `claim` to `claims`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,10 +15,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "claim"
-version = "0.5.0"
+name = "claims"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81099d6bb72e1df6d50bb2347224b666a670912bb7f06dbe867a4a070ab3ce8"
+checksum = "70417827831b0ea25b74bb976a601915e8a82a6643fb2fe726b40287f1aa98ef"
 dependencies = [
  "autocfg",
 ]
@@ -180,7 +180,7 @@ dependencies = [
 name = "tracing-bunyan-formatter"
 version = "0.3.3"
 dependencies = [
- "claim",
+ "claims",
  "gethostname",
  "lazy_static",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ tracing-core = "0.1.10"
 time = { version = "0.3", default-features = false, features = ["formatting"] }
 
 [dev-dependencies]
-claim = "0.5.0"
+claims = "0.6.0"
 lazy_static = "1.4.0"
 tracing = { version = "0.1.13", default-features = false, features = ["log", "std", "attributes"] }
 time = { version = "0.3", default-features = false, features = ["formatting", "parsing", "local-offset"] }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1,5 +1,5 @@
 use crate::mock_writer::MockWriter;
-use claim::assert_some_eq;
+use claims::assert_some_eq;
 use lazy_static::lazy_static;
 use serde_json::{json, Value};
 use std::collections::HashMap;


### PR DESCRIPTION
The former one is unfortunately unmaintained. `claims` is a recent fork with an improved bus factor 😅