### PR TITLE
Add the ability to skip fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ serde = "1.0.106"
 gethostname = "0.2.1"
 tracing-core = "0.1.10"
 time = { version = "0.3", default-features = false, features = ["formatting"] }
+ahash = "0.8.2"
 
 [dev-dependencies]
 claims = "0.6.0"

--- a/src/formatting_layer.rs
+++ b/src/formatting_layer.rs
@@ -1,5 +1,6 @@
 use crate::storage_layer::JsonStorage;
-use serde::ser::{SerializeMap, Serializer};
+use ahash::{HashSet, HashSetExt};
+use serde::ser::{Serialize, SerializeMap, Serializer};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::fmt;
@@ -48,7 +49,25 @@ pub struct BunyanFormattingLayer<W: for<'a> MakeWriter<'a> + 'static> {
     bunyan_version: u8,
     name: String,
     default_fields: HashMap<String, Value>,
+    skip_fields: HashSet<String>,
 }
+
+/// This error will be returned in [`BunyanFormattingLayer::skip_fields`] if trying to skip a core field.
+#[non_exhaustive]
+#[derive(Debug)]
+pub struct InvalidFieldError(String);
+
+impl fmt::Display for InvalidFieldError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} is a core field in the bunyan log format, it can't be skipped",
+            &self.0
+        )
+    }
+}
+
+impl std::error::Error for InvalidFieldError {}
 
 impl<W: for<'a> MakeWriter<'a> + 'static> BunyanFormattingLayer<W> {
     /// Create a new `BunyanFormattingLayer`.
@@ -86,7 +105,24 @@ impl<W: for<'a> MakeWriter<'a> + 'static> BunyanFormattingLayer<W> {
             hostname: gethostname::gethostname().to_string_lossy().into_owned(),
             bunyan_version: 0,
             default_fields,
+            skip_fields: HashSet::new(),
         }
+    }
+
+    /// Add fields to skip when formatting with this layer.
+    pub fn skip_fields<T>(mut self, fields: &[T]) -> Result<Self, InvalidFieldError>
+    where
+        T: AsRef<str>,
+    {
+        for field in fields {
+            let field = field.as_ref();
+            if BUNYAN_RESERVED_FIELDS.contains(&field) {
+                return Err(InvalidFieldError(field.to_string()));
+            }
+            self.skip_fields.insert(field.to_string());
+        }
+
+        Ok(self)
     }
 
     fn serialize_bunyan_core_fields(
@@ -107,6 +143,22 @@ impl<W: for<'a> MakeWriter<'a> + 'static> BunyanFormattingLayer<W> {
         Ok(())
     }
 
+    fn serialize_field<V>(
+        &self,
+        map_serializer: &mut impl SerializeMap<Error = serde_json::Error>,
+        key: &str,
+        value: &V,
+    ) -> Result<(), std::io::Error>
+    where
+        V: Serialize + ?Sized,
+    {
+        if !self.skip_fields.contains(key) {
+            map_serializer.serialize_entry(key, value)?;
+        }
+
+        Ok(())
+    }
+
     /// Given a span, it serialised it to a in-memory buffer (vector of bytes).
     fn serialize_span<S: Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>>(
         &self,
@@ -121,14 +173,14 @@ impl<W: for<'a> MakeWriter<'a> + 'static> BunyanFormattingLayer<W> {
         // Additional metadata useful for debugging
         // They should be nested under `src` (see https://github.com/trentm/node-bunyan#src )
         // but `tracing` does not support nested values yet
-        map_serializer.serialize_entry("target", span.metadata().target())?;
-        map_serializer.serialize_entry("line", &span.metadata().line())?;
-        map_serializer.serialize_entry("file", &span.metadata().file())?;
+        self.serialize_field(&mut map_serializer, "target", span.metadata().target())?;
+        self.serialize_field(&mut map_serializer, "line", &span.metadata().line())?;
+        self.serialize_field(&mut map_serializer, "file", &span.metadata().file())?;
 
         // Add all default fields
         for (key, value) in self.default_fields.iter() {
             if !BUNYAN_RESERVED_FIELDS.contains(&key.as_str()) {
-                map_serializer.serialize_entry(key, value)?;
+                self.serialize_field(&mut map_serializer, key, value)?;
             } else {
                 tracing::debug!(
                     "{} is a reserved field in the bunyan log format. Skipping it.",
@@ -141,7 +193,7 @@ impl<W: for<'a> MakeWriter<'a> + 'static> BunyanFormattingLayer<W> {
         if let Some(visitor) = extensions.get::<JsonStorage>() {
             for (key, value) in visitor.values() {
                 if !BUNYAN_RESERVED_FIELDS.contains(key) {
-                    map_serializer.serialize_entry(key, value)?;
+                    self.serialize_field(&mut map_serializer, key, value)?;
                 } else {
                     tracing::debug!(
                         "{} is a reserved field in the bunyan log format. Skipping it.",
@@ -256,15 +308,15 @@ where
             // Additional metadata useful for debugging
             // They should be nested under `src` (see https://github.com/trentm/node-bunyan#src )
             // but `tracing` does not support nested values yet
-            map_serializer.serialize_entry("target", event.metadata().target())?;
-            map_serializer.serialize_entry("line", &event.metadata().line())?;
-            map_serializer.serialize_entry("file", &event.metadata().file())?;
+            self.serialize_field(&mut map_serializer, "target", event.metadata().target())?;
+            self.serialize_field(&mut map_serializer, "line", &event.metadata().line())?;
+            self.serialize_field(&mut map_serializer, "file", &event.metadata().file())?;
 
             // Add all default fields
             for (key, value) in self.default_fields.iter().filter(|(key, _)| {
                 key.as_str() != "message" && !BUNYAN_RESERVED_FIELDS.contains(&key.as_str())
             }) {
-                map_serializer.serialize_entry(key, value)?;
+                self.serialize_field(&mut map_serializer, key, value)?;
             }
 
             // Add all the other fields associated with the event, expect the message we already used.
@@ -273,7 +325,7 @@ where
                 .iter()
                 .filter(|(&key, _)| key != "message" && !BUNYAN_RESERVED_FIELDS.contains(&key))
             {
-                map_serializer.serialize_entry(key, value)?;
+                self.serialize_field(&mut map_serializer, key, value)?;
             }
 
             // Add all the fields from the current span, if we have one.
@@ -282,7 +334,7 @@ where
                 if let Some(visitor) = extensions.get::<JsonStorage>() {
                     for (key, value) in visitor.values() {
                         if !BUNYAN_RESERVED_FIELDS.contains(key) {
-                            map_serializer.serialize_entry(key, value)?;
+                            self.serialize_field(&mut map_serializer, key, value)?;
                         } else {
                             tracing::debug!(
                                 "{} is a reserved field in the bunyan log format. Skipping it.",

--- a/src/formatting_layer.rs
+++ b/src/formatting_layer.rs
@@ -4,6 +4,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::fmt;
 use std::io::Write;
+use time::format_description::well_known::Rfc3339;
 use tracing::{Event, Id, Subscriber};
 use tracing_core::metadata::Level;
 use tracing_core::span::Attributes;
@@ -12,7 +13,6 @@ use tracing_subscriber::fmt::MakeWriter;
 use tracing_subscriber::layer::Context;
 use tracing_subscriber::registry::SpanRef;
 use tracing_subscriber::Layer;
-use time::format_description::well_known::Rfc3339;
 
 /// Keys for core fields of the Bunyan format (https://github.com/trentm/node-bunyan#core-fields)
 const BUNYAN_VERSION: &str = "v";
@@ -74,7 +74,11 @@ impl<W: for<'a> MakeWriter<'a> + 'static> BunyanFormattingLayer<W> {
         Self::with_default_fields(name, make_writer, HashMap::new())
     }
 
-    pub fn with_default_fields(name: String, make_writer: W, default_fields: HashMap<String, Value>) -> Self {
+    pub fn with_default_fields(
+        name: String,
+        make_writer: W,
+        default_fields: HashMap<String, Value>,
+    ) -> Self {
         Self {
             make_writer,
             name,
@@ -127,9 +131,9 @@ impl<W: for<'a> MakeWriter<'a> + 'static> BunyanFormattingLayer<W> {
                 map_serializer.serialize_entry(key, value)?;
             } else {
                 tracing::debug!(
-                        "{} is a reserved field in the bunyan log format. Skipping it.",
-                        key
-                    );
+                    "{} is a reserved field in the bunyan log format. Skipping it.",
+                    key
+                );
             }
         }
 
@@ -257,10 +261,9 @@ where
             map_serializer.serialize_entry("file", &event.metadata().file())?;
 
             // Add all default fields
-            for (key, value) in self.default_fields
-                .iter()
-                .filter(|(key, _)| key.as_str() != "message" && !BUNYAN_RESERVED_FIELDS.contains(&key.as_str()))
-            {
+            for (key, value) in self.default_fields.iter().filter(|(key, _)| {
+                key.as_str() != "message" && !BUNYAN_RESERVED_FIELDS.contains(&key.as_str())
+            }) {
                 map_serializer.serialize_entry(key, value)?;
             }
 

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -23,7 +23,11 @@ lazy_static! {
 fn run_and_get_raw_output<F: Fn()>(action: F) -> String {
     let mut default_fields = HashMap::new();
     default_fields.insert("custom_field".to_string(), json!("custom_value"));
-    let formatting_layer = BunyanFormattingLayer::with_default_fields("test".into(), || MockWriter::new(&BUFFER), default_fields);
+    let formatting_layer = BunyanFormattingLayer::with_default_fields(
+        "test".into(),
+        || MockWriter::new(&BUFFER),
+        default_fields,
+    );
     let subscriber = Registry::default()
         .with(JsonStorageLayer)
         .with(formatting_layer);


### PR DESCRIPTION
*Issue #, if available:* #16

*Description of changes:*

This PR adds the ability to skip fields in the output of the `BunyanFormattingLayer`. I _think_ this solves issue #16 but I'm not 100% sure.

I wanted this feature myself to skip the fields `file`, `line` and `target` because they're quite spammy and not all that useful for me.
I'm still relatively new to Rust so let me know if anything is obviously bad or wrong.
Note: the first commit is just running `cargo fmt` to avoid polluting the actual commit with formatting changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
