### PR TITLE
Allow lib to build for all targets/platforms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,11 @@ categories = ["development-tools::profiling", "development-tools::debugging"]
 path = "src/lib.rs"
 
 [features]
-default = []
+default = ["hostname"]
 arbitrary-precision = ["serde_json/arbitrary_precision"]
 valuable = ["tracing/valuable", "dep:valuable", "dep:valuable-serde"]
-
+hostname =  ["gethostname"]
+ 
 [dependencies]
 tracing = { version = "0.1.13", default-features = false, features = ["log", "std"] }
 tracing-subscriber = { version = "0.3.16", default-features = false, features = ["registry", "fmt"] }
@@ -30,7 +31,7 @@ tracing-log = { version = "0.1" }
 log = "0.4.8"
 serde_json = { version = "1.0.52" }
 serde = "1.0.106"
-gethostname = "0.2.1"
+gethostname = { version = "0.2.1", optional = true }
 tracing-core = "0.1.10"
 time = { version = "0.3", default-features = false, features = ["formatting"] }
 ahash = "0.8.2"

--- a/src/formatting_layer.rs
+++ b/src/formatting_layer.rs
@@ -42,6 +42,7 @@ fn to_bunyan_level(level: &Level) -> u16 {
 /// This layer is exclusively concerned with formatting information using the [Bunyan format](https://github.com/trentm/node-bunyan).
 /// It relies on the upstream `JsonStorageLayer` to get access to the fields attached to
 /// each span.
+#[derive(Default)]
 pub struct BunyanFormattingLayer<W: for<'a> MakeWriter<'a> + 'static> {
     make_writer: W,
     pid: u32,
@@ -119,7 +120,10 @@ impl<W: for<'a> MakeWriter<'a> + 'static> BunyanFormattingLayer<W> {
             make_writer,
             name,
             pid: std::process::id(),
+            #[cfg(feature = "hostname")]
             hostname: gethostname::gethostname().to_string_lossy().into_owned(),
+            #[cfg(not(feature = "hostname"))]
+            hostname: Default::default(),
             bunyan_version: 0,
             default_fields,
             skip_fields: HashSet::new(),


### PR DESCRIPTION
This addresses: #12  

PR Adds a `hostname` feature which activates `gethostname` dependency and gates it's usage.
It adds a `#[derive(Default)]` to the `BunyanFormattingLayer` struct so that the default value (<no_hostname>) of field `HOSTNAME` can be used if the `hostname` feature is NOT enabled. 

This does not change the API and allows the lib to build for any target. It does not allow user to set a hostname (would likely require a change in the public API?) 

Let me know if this can be improved/changed in any way. 